### PR TITLE
[FEAT] 매도 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,19 +27,29 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'io.projectreactor:reactor-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
 	implementation 'me.paulschwarz:spring-dotenv:2.3.0'
-	implementation 'org.springframework.boot:spring-boot-starter-webflux'
-	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'io.projectreactor:reactor-test'
+	testImplementation 'org.springframework.security:spring-security-test'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/iotl/controller/OrderController.java
+++ b/src/main/java/com/example/iotl/controller/OrderController.java
@@ -3,9 +3,12 @@ package com.example.iotl.controller;
 
 
 
+import com.example.iotl.dto.OrderHistoryDto;
 import com.example.iotl.dto.OrderRequestDto;
 import com.example.iotl.dto.OrderResponseDto;
+import com.example.iotl.entity.User;
 import com.example.iotl.service.OrderService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -22,4 +25,20 @@ public class OrderController {
         OrderResponseDto response = orderService.placeOrder(requestDto);
         return ResponseEntity.ok(response);
     }
+
+    // 👉 주문 내역 조회 API
+    @GetMapping("/history")
+    public List<OrderHistoryDto> getOrderHistory(
+        @RequestParam("userId") Long userId,
+        @RequestParam("stockCode") String stockCode) {
+
+        // 테스트용 코드: 실제 로그인 사용자 기반으로 바꾸는 게 좋음
+        User user = new User(); // 👈 실제 로그인 사용자에서 가져와야 함
+        user.setUserId(userId);
+
+        return orderService.getOrderHistoryByUserAndStock(user, stockCode);
+    }
+
+
+
 }

--- a/src/main/java/com/example/iotl/controller/TradeController.java
+++ b/src/main/java/com/example/iotl/controller/TradeController.java
@@ -1,0 +1,34 @@
+package com.example.iotl.controller;
+
+import com.example.iotl.dto.OrderHistoryDto;
+import com.example.iotl.dto.TradeDto;
+import com.example.iotl.entity.User;
+import com.example.iotl.repository.UserRepository;
+import com.example.iotl.service.TradeService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/trades")
+@RequiredArgsConstructor
+public class TradeController {
+    private final UserRepository userRepository;
+    private final TradeService tradeService;
+
+    @GetMapping
+    public ResponseEntity<List<TradeDto>> getTrades(
+        @RequestParam Long userId,
+        @RequestParam String stockCode) {
+
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        return ResponseEntity.ok(tradeService.getTradesByUserAndStock(user, stockCode));
+    }
+
+}

--- a/src/main/java/com/example/iotl/dto/OrderHistoryDto.java
+++ b/src/main/java/com/example/iotl/dto/OrderHistoryDto.java
@@ -1,0 +1,39 @@
+package com.example.iotl.dto;
+
+import com.example.iotl.entity.Order;
+import com.example.iotl.entity.Order.OrderStatus;
+import com.example.iotl.entity.Order.OrderType;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderHistoryDto {
+    private Long orderId;
+    private OrderType orderType;
+    private String stockCode;
+    private int quantity;
+    private BigDecimal price;
+    private OrderStatus status;
+    private LocalDateTime createdAt;
+
+    public static OrderHistoryDto from(Order order) {
+        return OrderHistoryDto.builder()
+            .orderId(order.getId())
+            .orderType(order.getOrderType())
+            .stockCode(order.getStock().getStockCode())
+            .quantity(order.getQuantity())
+            .price(order.getPrice())
+            .status(order.getStatus())
+            .createdAt(order.getCreatedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/example/iotl/dto/TradeDto.java
+++ b/src/main/java/com/example/iotl/dto/TradeDto.java
@@ -1,0 +1,39 @@
+package com.example.iotl.dto;
+
+import com.example.iotl.entity.Order.OrderType;
+import com.example.iotl.entity.Trade;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TradeDto {
+
+    private Long tradeId;
+    private Long orderId;
+    private String stockCode;
+    private OrderType orderType;
+    private BigDecimal executedPrice;
+    private Integer executedQuantity;
+    private LocalDateTime executedAt;
+
+    public static TradeDto from(Trade trade) {
+        return TradeDto.builder()
+            .tradeId(trade.getId())
+            .orderId(trade.getOrder().getId())
+            .stockCode(trade.getOrder().getStock().getStockCode())
+            .orderType(trade.getOrder().getOrderType())
+            .executedPrice(trade.getExecutedPrice())
+            .executedQuantity(trade.getExecutedQuantity())
+            .executedAt(trade.getExecutedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/example/iotl/entity/Trade.java
+++ b/src/main/java/com/example/iotl/entity/Trade.java
@@ -1,5 +1,6 @@
 package com.example.iotl.entity;
 
+import com.example.iotl.entity.Order.OrderType;
 import jakarta.persistence.*;
 import lombok.*;
 import java.math.BigDecimal;
@@ -35,4 +36,9 @@ public class Trade {
     protected void onExecute() {
         this.executedAt = LocalDateTime.now();
     }
+
+    @Column(name = "order_type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private OrderType orderType;
+
 }

--- a/src/main/java/com/example/iotl/repository/HoldingsRepository.java
+++ b/src/main/java/com/example/iotl/repository/HoldingsRepository.java
@@ -1,8 +1,13 @@
 package com.example.iotl.repository;
 
 import com.example.iotl.entity.Holdings;
+import com.example.iotl.entity.Stocks;
+import com.example.iotl.entity.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HoldingsRepository extends JpaRepository<Holdings,Long> {
+
+    Optional<Holdings> findByUserAndStock(User user, Stocks stock);
 
 }

--- a/src/main/java/com/example/iotl/repository/OrderRepository.java
+++ b/src/main/java/com/example/iotl/repository/OrderRepository.java
@@ -1,8 +1,38 @@
 package com.example.iotl.repository;
 
 import com.example.iotl.entity.Order;
+import com.example.iotl.entity.Order.OrderStatus;
+import com.example.iotl.entity.Order.OrderType;
+import com.example.iotl.entity.User;
+import java.math.BigDecimal;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface OrderRepository extends JpaRepository<Order,Long> {
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+    // 1. 주문 매칭 (체결용)
+    @Query("SELECT o FROM Order o " +
+        "WHERE o.status = 'PENDING' " +
+        "AND o.orderType = :orderType " +
+        "AND o.stock.stockCode = :stockCode " +
+        "AND o.price = :price " +
+        "ORDER BY o.createdAt ASC")
+    List<Order> findMatchingOrders(@Param("orderType") OrderType orderType,
+        @Param("stockCode") String stockCode,
+        @Param("price") BigDecimal price);
+
+    // 2. 사용자 주문 내역 - 대기 중(PENDING)
+    List<Order> findByUserAndStock_StockCodeAndStatus(User user, String stockCode, OrderStatus status);
+
+    // 3. 사용자 주문 내역 - 체결됨 (COMPLETED or PARTIAL)
+    List<Order> findByUserAndStock_StockCodeAndStatusIn(User user, String stockCode, List<OrderStatus> statuses);
+
+    List<Order> findByUserAndStock_StockCode(User user, String stockCode);
+
+
+
+
 
 }

--- a/src/main/java/com/example/iotl/repository/TradeRepository.java
+++ b/src/main/java/com/example/iotl/repository/TradeRepository.java
@@ -1,9 +1,14 @@
 package com.example.iotl.repository;
 
 import com.example.iotl.entity.Trade;
+import com.example.iotl.entity.User;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TradeRepository extends JpaRepository<Trade,Long> {
+
+
+    List<Trade> findByOrder_UserAndOrder_Stock_StockCode(User user, String stockCode);
 
 
 }

--- a/src/main/java/com/example/iotl/service/OrderMatchingService.java
+++ b/src/main/java/com/example/iotl/service/OrderMatchingService.java
@@ -1,0 +1,48 @@
+package com.example.iotl.service;
+
+
+import com.example.iotl.entity.Order;
+import com.example.iotl.entity.Order.OrderType;
+import com.example.iotl.repository.OrderRepository;
+import com.example.iotl.repository.TradeRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OrderMatchingService {
+    private final OrderRepository orderRepository;
+    private final TradeRepository tradeRepository;
+    private final TradeService tradeService;
+
+
+    //신규 주문이 들어오면,
+    //대기 중인 반대 주문과 자동 매칭을 시도하고,
+    //체결 가능한 경우 TradeService를 통해 체결까지 연결시키기
+
+    public void match(Order newOrder) {
+            // 1. 반대 타입 주문 찾기
+            OrderType oppositeType = newOrder.getOrderType() == OrderType.BUY
+                ? OrderType.SELL
+                : OrderType.BUY;
+
+            // 2. 대기 상태이면서, 같은 종목에 대한 반대 주문 리스트 가져오기
+            List<Order> candidateOrders = orderRepository
+                .findMatchingOrders(oppositeType, newOrder.getStock().getStockCode(), newOrder.getPrice());
+
+            // 3. 매칭 조건이 되는 주문과 체결 시도
+            for (Order candidate : candidateOrders) {
+                // 가격 비교 조건 등 추가 가능
+                //newOrder는 사용자가 방금 등록한 주문이고,
+                // candidate는 반대 타입(예: 매수 시 매도)의 기존 주문 중 매칭된 대상
+                tradeService.trade(newOrder, candidate);
+                break;  // 단순 구현: 한 건만 체결 후 종료
+            }
+        }
+
+
+    }
+
+
+

--- a/src/main/java/com/example/iotl/service/OrderService.java
+++ b/src/main/java/com/example/iotl/service/OrderService.java
@@ -2,15 +2,19 @@ package com.example.iotl.service;
 
 import com.example.iotl.dto.OrderRequestDto;
 import com.example.iotl.dto.OrderResponseDto;
+import com.example.iotl.entity.Holdings;
 import com.example.iotl.entity.Order;
 import com.example.iotl.entity.Order.OrderStatus;
 import com.example.iotl.entity.Stocks;
 import com.example.iotl.entity.User;
+import com.example.iotl.repository.HoldingsRepository;
 import com.example.iotl.repository.OrderRepository;
 import com.example.iotl.repository.StockInfoRepository;
 import com.example.iotl.repository.StockRepository;
 import com.example.iotl.repository.UserRepository;
 import jakarta.transaction.Transactional;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,6 +25,7 @@ public class OrderService {
     private final OrderRepository orderRepository;
     private final UserRepository userRepository;
     private final StockInfoRepository stockInfoRepository;
+    private final HoldingsRepository holdingsRepository;
 
     @Transactional
     public OrderResponseDto placeOrder(OrderRequestDto requestDto) {
@@ -32,21 +37,70 @@ public class OrderService {
         Stocks stocks = stockInfoRepository.findById(requestDto.getStockCode())
             .orElseThrow(() -> new IllegalArgumentException("해당 주식이 존재하지 않습니다."));
 
-        // (3) Order 객체 생성
+        // (3) 주문 타입별 분기
+        switch (requestDto.getOrderType()) {
+            case BUY -> handleBuyOrder(user, stocks, requestDto);
+            case SELL -> handleSellOrder(user, stocks, requestDto);
+            default -> throw new IllegalArgumentException("지원하지 않는 주문 타입입니다.");
+        }
+
+        // (4) Order 객체 생성
         Order order = Order.builder()
             .user(user)
             .stock(stocks)
-            .orderType(requestDto.getOrderType()) // BUY or SELL
+            .orderType(requestDto.getOrderType())
             .price(requestDto.getPrice())
-            .quantity(requestDto.getQuantity()) // 수량
-            .status(OrderStatus.valueOf("WAIT")) // 대기 상태로 기본 설정
+            .quantity(requestDto.getQuantity())
+            .status(OrderStatus.PENDING)
             .createdAt(LocalDateTime.now())
             .build();
 
-        // (4) 저장
+        // (5) 저장
         orderRepository.save(order);
         return OrderResponseDto.from(order);
     }
+
+
+
+    private void handleBuyOrder(User user, Stocks stock, OrderRequestDto dto) {
+        // 가격과 수량 유효성 검사
+        if (dto.getPrice().compareTo(BigDecimal.ZERO) <= 0 || dto.getQuantity() <= 0) {
+            throw new IllegalArgumentException("가격과 수량은 0보다 커야 합니다.");
+        }
+        // 총 주문 금액 = 가격 × 수량
+        BigDecimal totalCost = dto.getPrice().multiply(BigDecimal.valueOf(dto.getQuantity()));
+        BigDecimal currentBalance = user.getAccount().getBalance();
+
+        if (currentBalance.compareTo(totalCost) < 0) {
+            throw new IllegalStateException("예수금이 부족합니다.");
+        }
+
+        BigDecimal updatedBalance = currentBalance.subtract(totalCost);
+        user.getAccount().setBalance(updatedBalance.setScale(2, RoundingMode.HALF_UP));
+    }
+
+
+    private void handleSellOrder(User user, Stocks stock, OrderRequestDto dto) {
+        // (1) 보유 종목 조회
+
+        Holdings holding = holdingsRepository.findByUserAndStock(user, stock)
+            .orElseThrow(() -> new IllegalArgumentException("해당 종목을 보유하고 있지 않습니다."));
+
+        // (2) 보유 수량 >= 매도 수량 확인
+        if (holding.getQuantity() < dto.getQuantity()) {
+            throw new IllegalStateException("보유 수량이 부족합니다.");
+        }
+
+        // (3) 보유 수량 차감
+        holding.setQuantity(holding.getQuantity() - dto.getQuantity());
+
+        // (4) 매도 금액 계산 후 예수금 증가
+        BigDecimal sellAmount = dto.getPrice().multiply(BigDecimal.valueOf(dto.getQuantity()));
+        BigDecimal updatedBalance = user.getAccount().getBalance().add(sellAmount);
+
+        user.getAccount().setBalance(updatedBalance.setScale(2, RoundingMode.HALF_UP));
+    }
+
 
 
 }

--- a/src/main/java/com/example/iotl/service/TradeService.java
+++ b/src/main/java/com/example/iotl/service/TradeService.java
@@ -1,29 +1,120 @@
 package com.example.iotl.service;
 
-import com.example.iotl.repository.AccountsRepository;
+import com.example.iotl.dto.OrderHistoryDto;
+import com.example.iotl.dto.TradeDto;
+import com.example.iotl.entity.*;
+import com.example.iotl.entity.Order.OrderStatus;
+import com.example.iotl.entity.Order.OrderType;
 import com.example.iotl.repository.HoldingsRepository;
 import com.example.iotl.repository.OrderRepository;
-import com.example.iotl.repository.StockRepository;
 import com.example.iotl.repository.TradeRepository;
-import com.example.iotl.repository.UserRepository;
-import org.springframework.transaction.annotation.Transactional;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 @Service
 @RequiredArgsConstructor
 public class TradeService {
 
-    private final UserRepository userRepository;
-    private final AccountsRepository accountRepository;
-    private final StockRepository stockRepository;
     private final HoldingsRepository holdingsRepository;
     private final OrderRepository orderRepository;
     private final TradeRepository tradeRepository;
 
     @Transactional
-    public void buyStock(Long userId, String stockCode, int quantity, BigDecimal price) {
-        // TODO: 매수 로직 구현
+    public void trade(Order newOrder, Order matchedOrder) {
+        // 1. 매수/매도 주문 판별
+        Order buyOrder = (newOrder.getOrderType() == OrderType.BUY) ? newOrder : matchedOrder;
+        Order sellOrder = (newOrder.getOrderType() == OrderType.SELL) ? newOrder : matchedOrder;
+
+        // 2. 가격 & 최대 체결 수량 계산
+        BigDecimal price = buyOrder.getPrice();  // 동일 가격 매칭 가정
+        int maxQuantity = Math.min(buyOrder.getQuantity(), sellOrder.getQuantity());
+
+        // 3. 매도자의 실제 보유 수량 확인
+        Holdings sellerHoldings = holdingsRepository.findByUserAndStock(sellOrder.getUser(),
+                sellOrder.getStock())
+            .orElseThrow(() -> new IllegalStateException("매도자의 주식 보유 정보가 없습니다."));
+
+        // 4. 실제 체결 가능한 수량 계산
+        int tradeQuantity = Math.min(maxQuantity, sellerHoldings.getQuantity());
+        if (tradeQuantity <= 0) {
+            throw new IllegalStateException("체결 가능한 수량이 없습니다.");
+        }
+
+        // 5. 매수자의 예수금 확인
+        BigDecimal totalCost = price.multiply(BigDecimal.valueOf(tradeQuantity));
+        if (buyOrder.getUser().getAccount().getBalance().compareTo(totalCost) < 0) {
+            throw new IllegalStateException("매수자의 예수금이 부족합니다.");
+        }
+
+        // 6. 자산 이동
+        buyOrder.getUser().getAccount().setBalance(
+            buyOrder.getUser().getAccount().getBalance()
+                .subtract(totalCost).setScale(2, RoundingMode.HALF_UP)
+        );
+
+        sellOrder.getUser().getAccount().setBalance(
+            sellOrder.getUser().getAccount().getBalance()
+                .add(totalCost).setScale(2, RoundingMode.HALF_UP)
+        );
+
+        // 7. 주식 이동
+        sellerHoldings.setQuantity(sellerHoldings.getQuantity() - tradeQuantity);
+
+        // 매수자 보유 종목 확인 or 신규 생성
+        Holdings buyerHoldings = holdingsRepository.findByUserAndStock(buyOrder.getUser(),
+                buyOrder.getStock())
+            .orElse(
+                Holdings.builder()
+                    .user(buyOrder.getUser())
+                    .stock(buyOrder.getStock())
+                    .quantity(0)
+                    .averageBuyPrice(BigDecimal.ZERO)
+                    .build()
+            );
+
+        buyerHoldings.setQuantity(buyerHoldings.getQuantity() + tradeQuantity);
+
+        holdingsRepository.save(sellerHoldings);
+        holdingsRepository.save(buyerHoldings);
+
+        // 8. 주문 수량 업데이트
+        buyOrder.setQuantity(buyOrder.getQuantity() - tradeQuantity);
+        sellOrder.setQuantity(sellOrder.getQuantity() - tradeQuantity);
+
+        // 9. 주문 상태 업데이트
+        buyOrder.setStatus(
+            buyOrder.getQuantity() == 0 ? OrderStatus.COMPLETED : OrderStatus.PARTIAL);
+        sellOrder.setStatus(
+            sellOrder.getQuantity() == 0 ? OrderStatus.COMPLETED : OrderStatus.PARTIAL);
+
+        orderRepository.save(buyOrder);
+        orderRepository.save(sellOrder);
+
+        // 10. 체결 기록 저장
+        OrderType executedType = (buyOrder.equals(newOrder)) ? OrderType.BUY : OrderType.SELL;
+
+        Trade tradeRecord = Trade.builder()
+            .order(newOrder)  // 주체가 된 주문 저장
+            .orderType(executedType)
+            .executedPrice(price)
+            .executedQuantity(tradeQuantity)
+            .build();
+
+        tradeRepository.save(tradeRecord);
+
+
     }
 
+    public List<TradeDto> getTradesByUserAndStock(User user, String stockCode) {
+        return tradeRepository.findByOrder_UserAndOrder_Stock_StockCode(user, stockCode)
+            .stream()
+            .map(TradeDto::from)
+            .collect(Collectors.toList());
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,10 +35,9 @@ spring:
             scope:
               - name
               - email
-
           google:
             client-name: google
-            client-id:
+            client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
             redirect-uri: http://localhost:8080/login/oauth2/code/google
             authorization-grant-type: authorization_code
@@ -59,19 +58,11 @@ kis:
     appsecret: ${KIS_CLIENT_SECRET}
     access-token:
 
-
 exchange:
   api:
     base-url: ${EXCHAGE_URL}
     base-currency: USD
 
-naver:
-  client-id: ${NAVER_NEWS_CLIENT_ID}
-  client-secret: ${NAVER_NEWS_CLIENT_SECRET}
-  news-url: ${NAVER_API_URL}
 
 server:
   port: 8080
-
-
-


### PR DESCRIPTION
✨ 주문 및 체결 기능 분리 및 구현

[Order 기능]
- OrderController: 주문 등록 및 주문 내역 조회 API 구현
- OrderHistoryDto: 주문 정보 DTO 생성 (주문/체결 분리 준비)
- OrderMatchingService: 신규 주문 시 dev 브랜치로부터 매칭 로직 수행
- OrderRepository: 반대 타입(PENDING 상태) 주문 조회 쿼리 추가
- OrderService: 주문 생성 및 매칭 서비스 연동 처리

[Trade 기능]
- TradeController: 유저 + 종목 기준 체결 내역 조회 API 구현
- TradeDto: 체결 정보 응답용 DTO 정의
- TradeRepository: 유저 + 종목 기준 체결 내역 쿼리 메서드 추가
- TradeService: 체결 정보 저장 및 체결 내역 조회 로직 구현
