### PR TITLE
[Feat] username 추출 로직 추가 및 api 컨벤션 적용

### DIFF
--- a/src/main/java/com/example/iotl/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/iotl/config/security/SecurityConfig.java
@@ -48,26 +48,32 @@ public class SecurityConfig {
 
         //csrf disable
         http
-                .csrf((auth) -> auth.disable());
+            .csrf((auth) -> auth.disable());
 
         //From 로그인 방식 disable
         http
-                .formLogin((auth) -> auth.disable());
+            .formLogin((auth) -> auth.disable());
 
         //HTTP Basic 인증 방식 disable
         http
-                .httpBasic((auth) -> auth.disable());
+            .httpBasic((auth) -> auth.disable());
 
         //JWTFilter 추가
         http
-                .addFilterAfter(jwtFilter(), UsernamePasswordAuthenticationFilter.class);
+            .addFilterAfter(jwtFilter(), UsernamePasswordAuthenticationFilter.class);
 
         //oauth2
         http
-                .oauth2Login((oauth2) -> oauth2
-                        .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
-                                .userService(customOAuth2UserService))
-                        .successHandler(customSuccessHandler));
+            .oauth2Login((oauth2) -> oauth2
+                .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
+                    .userService(customOAuth2UserService))
+                .successHandler(customSuccessHandler));
+
+        // //배포전 모든 경로 허용
+        // http
+        //     .authorizeHttpRequests((auth) -> auth
+        //         .anyRequest().permitAll()
+        //     );
 
         //경로별 인가 작업
         http
@@ -79,33 +85,33 @@ public class SecurityConfig {
 
         //세션 설정 : STATELESS
         http
-                .sessionManagement((session) -> session
-                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+            .sessionManagement((session) -> session
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         http
-                .cors(corsCustomizer -> corsCustomizer.configurationSource(new CorsConfigurationSource() {
-                    @Override
-                    public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
-                        CorsConfiguration configuration = new CorsConfiguration();
+            .cors(corsCustomizer -> corsCustomizer.configurationSource(new CorsConfigurationSource() {
+                @Override
+                public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
+                    CorsConfiguration configuration = new CorsConfiguration();
 
-                        configuration.setAllowedOrigins(List.of(
-                                "http://127.0.0.1:5500",
-                                "http://localhost:8080",
-                                "https://iotl-fe.vercel.app",
-                                "https://localhost:5173",
-                                "http://localhost:5173",
-                                "https://localhost:5137",
-                                "http://localhost:5137"
-                        ));
-                        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-                        configuration.setAllowedHeaders(List.of("*"));
-                        configuration.setExposedHeaders(List.of("Set-Cookie", "Authorization"));
-                        configuration.setAllowCredentials(true);
-                        configuration.setMaxAge(3600L);
+                    configuration.setAllowedOrigins(List.of(
+                        "http://127.0.0.1:5500",
+                        "http://localhost:8080",
+                        "https://iotl-fe.vercel.app",
+                        "https://localhost:5173",
+                        "http://localhost:5173",
+                        "https://localhost:5137",
+                        "http://localhost:5137"
+                    ));
+                    configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+                    configuration.setAllowedHeaders(List.of("*"));
+                    configuration.setExposedHeaders(List.of("Set-Cookie", "Authorization"));
+                    configuration.setAllowCredentials(true);
+                    configuration.setMaxAge(3600L);
 
-                        return configuration;
-                    }
-                }));
+                    return configuration;
+                }
+            }));
 
         return http.build();
     }

--- a/src/main/java/com/example/iotl/controller/NewsController.java
+++ b/src/main/java/com/example/iotl/controller/NewsController.java
@@ -14,8 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @CrossOrigin(origins = "*") // 또는 허용할 도메인만 지정
 @Tag(name = "News API", description = "뉴스 관련 API (Naver News OpenAPI 기반)")
 @RestController
-// @RequestMapping("/auth/api/v1/news")
-@RequestMapping("/api/v1/news")
+@RequestMapping("/auth/api/v1/news")
 @RequiredArgsConstructor
 public class NewsController {
 

--- a/src/main/java/com/example/iotl/controller/NewsController.java
+++ b/src/main/java/com/example/iotl/controller/NewsController.java
@@ -14,7 +14,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @CrossOrigin(origins = "*") // 또는 허용할 도메인만 지정
 @Tag(name = "News API", description = "뉴스 관련 API (Naver News OpenAPI 기반)")
 @RestController
-@RequestMapping("/auth/api/v1/news")
+// @RequestMapping("/auth/api/v1/news")
+@RequestMapping("/api/v1/news")
 @RequiredArgsConstructor
 public class NewsController {
 

--- a/src/main/java/com/example/iotl/controller/ReissueController.java
+++ b/src/main/java/com/example/iotl/controller/ReissueController.java
@@ -69,7 +69,7 @@ public class ReissueController {
 //    }
 //}
 
-    @PostMapping("/reissue")
+    @PostMapping("/auth/reissue")
     public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response) {
         String refresh = null;
         Cookie[] cookies = request.getCookies();
@@ -89,7 +89,7 @@ public class ReissueController {
         try {
             jwtUtil.isExpired(refresh);
         } catch (ExpiredJwtException e) {
-            return ResponseEntity.badRequest().body("refresh token expired");
+            return ResponseEntity.badRequest().body("refresh token expired - 다시 로그인해주세요");
         }
 
         if (!"refresh".equals(jwtUtil.getCategory(refresh))) {

--- a/src/main/java/com/example/iotl/controller/TestController.java
+++ b/src/main/java/com/example/iotl/controller/TestController.java
@@ -1,8 +1,12 @@
 package com.example.iotl.controller;
 
 import com.example.iotl.domain.TestEntity;
+import com.example.iotl.jwt.AuthenticationUtils;
 import com.example.iotl.repository.TestEntityRepository;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -23,5 +27,16 @@ public class TestController {
     @GetMapping
     public String save() {
         return "save_test";
+    }
+
+    @GetMapping("/2")
+    public String test2() {
+        return "test2";
+    }
+
+    @GetMapping("/getUsername")
+    public String usernameTest() {
+        String username = AuthenticationUtils.getCurrentUsername();
+        return "Current username: " + username;
     }
 }

--- a/src/main/java/com/example/iotl/controller/TestControllerAuth.java
+++ b/src/main/java/com/example/iotl/controller/TestControllerAuth.java
@@ -1,0 +1,49 @@
+package com.example.iotl.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.iotl.repository.TestEntityRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth/test")
+public class TestControllerAuth {
+
+	@GetMapping
+	public String test() {
+		return "인증이 필요없는 테스트";
+	}
+
+	@GetMapping("/getUsername")
+	public String authTest1() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		// 로그인되지 않은 경우
+		if (authentication == null || !authentication.isAuthenticated()) {
+			return "Unauthorized";
+		}
+
+		// username 추출 (principal은 기본적으로 UserDetails 혹은 문자열 username)
+		Object principal = authentication.getPrincipal();
+		String username;
+
+		if (principal instanceof org.springframework.security.core.userdetails.UserDetails userDetails) {
+			username = userDetails.getUsername();
+		} else {
+			username = principal.toString(); // 일반적으로는 그냥 username
+		}
+
+		return "Current username: " + username;
+	}
+}

--- a/src/main/java/com/example/iotl/controller/UserController.java
+++ b/src/main/java/com/example/iotl/controller/UserController.java
@@ -1,0 +1,39 @@
+package com.example.iotl.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.iotl.dto.UserInfoDto;
+import com.example.iotl.dto.security.CustomOAuth2User;
+import com.example.iotl.service.security.CustomOAuth2UserService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/user")
+@RequiredArgsConstructor
+public class UserController {
+
+	private final CustomOAuth2UserService customOAuth2UserService;
+
+	@GetMapping("/userinfo")
+	public ResponseEntity<?> getUserInfo() {
+		try {
+			Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+			CustomOAuth2User userDetails = (CustomOAuth2User) authentication.getPrincipal();
+
+			String username = userDetails.getUsername();
+			UserInfoDto userInfo = customOAuth2UserService.getNameAndCreatedAt(username);
+			return ResponseEntity.ok(userInfo);
+		} catch (IllegalArgumentException e) {
+			return ResponseEntity.status(404).body(e.getMessage());
+		} catch (Exception e) {
+			return ResponseEntity.internalServerError().body("서버 오류가 발생했습니다.");
+		}
+	}
+}

--- a/src/main/java/com/example/iotl/filter/JWTFilter.java
+++ b/src/main/java/com/example/iotl/filter/JWTFilter.java
@@ -31,17 +31,23 @@ public class JWTFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-            throws ServletException, IOException {
+        throws ServletException, IOException {
 
         String uri = request.getRequestURI();
         log.info("Requested URI: {}", uri);
         log.info("Permit all paths: {}", permitAllPaths);
 
-        // ✅ WebSocket 요청은 무조건 허용
+        //  WebSocket 요청은 무조건 허용
         if (uri.startsWith("/ws/")) {
             filterChain.doFilter(request, response);
             return;
         }
+
+        // //모든 요청 허용 -> 실무에서 삭제
+        // if(uri.startsWith("/")) {
+        //     filterChain.doFilter(request, response);
+        //     return;
+        // }
 
         if (isPermitAllPath(uri)) {
             filterChain.doFilter(request, response);
@@ -92,7 +98,7 @@ public class JWTFilter extends OncePerRequestFilter {
 
         CustomOAuth2User customUserDetails = new CustomOAuth2User(userDto);
         Authentication authToken = new UsernamePasswordAuthenticationToken(
-                customUserDetails, null, customUserDetails.getAuthorities()
+            customUserDetails, null, customUserDetails.getAuthorities()
         );
         SecurityContextHolder.getContext().setAuthentication(authToken);
 
@@ -103,12 +109,12 @@ public class JWTFilter extends OncePerRequestFilter {
     // 설정한 api 경로 허용
     private boolean isPermitAllPath(String uri) {
         return permitAllPaths.stream()
-                .anyMatch(path -> {
-                    if (path.endsWith("/")) {
-                        return uri.startsWith(path); // 경로 접두사 매칭
-                    } else {
-                        return uri.equals(path); // 정확히 일치
-                    }
-                });
+            .anyMatch(path -> {
+                if (path.endsWith("/")) {
+                    return uri.startsWith(path); // 경로 접두사 매칭
+                } else {
+                    return uri.equals(path); // 정확히 일치
+                }
+            });
     }
 }

--- a/src/main/java/com/example/iotl/handler/CustomSuccessHandler.java
+++ b/src/main/java/com/example/iotl/handler/CustomSuccessHandler.java
@@ -51,7 +51,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         log.info("Redirecting to front - main Page After Successful Login");
         // ✅ 리다이렉트로 프론트 진입
-        response.sendRedirect("https://iotl-fe.vercel.app/");
-       // response.sendRedirect("http://localhost:5173/");
+        // response.sendRedirect("https://iotl-fe.vercel.app/");
+        response.sendRedirect("http://localhost:5173/");
     }
 }

--- a/src/main/java/com/example/iotl/handler/CustomSuccessHandler.java
+++ b/src/main/java/com/example/iotl/handler/CustomSuccessHandler.java
@@ -51,7 +51,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         log.info("Redirecting to front - main Page After Successful Login");
         // ✅ 리다이렉트로 프론트 진입
-        // response.sendRedirect("https://iotl-fe.vercel.app/");
-        response.sendRedirect("http://localhost:5173/");
+        response.sendRedirect("https://iotl-fe.vercel.app/"); //배포용
+        // response.sendRedirect("http://localhost:5173/");      //테스트용
     }
 }

--- a/src/main/java/com/example/iotl/jwt/AuthenticationUtils.java
+++ b/src/main/java/com/example/iotl/jwt/AuthenticationUtils.java
@@ -1,0 +1,36 @@
+package com.example.iotl.jwt;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+// public class AuthenticationUtils {
+// 	public static String getCurrentUsername() {
+// 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+// 		if (authentication == null || !authentication.isAuthenticated()) return null;
+//
+// 		Object principal = authentication.getPrincipal();
+// 		if (principal instanceof org.springframework.security.core.userdetails.UserDetails userDetails) {
+// 			return userDetails.getUsername();
+// 		} else {
+// 			return principal.toString();
+// 		}
+// 	}
+// }
+import com.example.iotl.dto.security.CustomOAuth2User;
+
+public class AuthenticationUtils {
+	public static String getCurrentUsername() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		if (authentication == null || !authentication.isAuthenticated()) return null;
+
+		Object principal = authentication.getPrincipal();
+
+		if (principal instanceof CustomOAuth2User customUser) {
+			return customUser.getUsername();
+		} else if (principal instanceof org.springframework.security.core.userdetails.UserDetails userDetails) {
+			return userDetails.getUsername();
+		} else {
+			return principal.toString(); // fallback
+		}
+	}
+}

--- a/src/main/java/com/example/iotl/service/security/TokenService.java
+++ b/src/main/java/com/example/iotl/service/security/TokenService.java
@@ -69,50 +69,50 @@ public class TokenService {
         return tokenMap;
     }
 
-    //배포용
-    //    public ResponseCookie createAccessCookie(String value) {
-    //        return ResponseCookie.from("access", value)
-    //                .maxAge(7 * 24 * 60 * 60) // 7일
-    //                .httpOnly(false) // ✅ JS에서 접근 가능
-    //                .secure(true)   // 로컬 개발 시 false
-    //                .sameSite("None")
-    //                .path("/")
-    // //                .domain("iotl.store")
-    //                .build();
-    //    }
+        //배포용
+       public ResponseCookie createAccessCookie(String value) {
+           return ResponseCookie.from("access", value)
+                   .maxAge(7 * 24 * 60 * 60) // 7일
+                   .httpOnly(false) // ✅ JS에서 접근 가능
+                   .secure(true)   // 로컬 개발 시 false
+                   .sameSite("None")
+                   .path("/")
+    //                .domain("iotl.store")
+                   .build();
+       }
+
+       public ResponseCookie createRefreshCookie(String value) {
+           return ResponseCookie.from("refresh", value)
+                   .maxAge(7 * 24 * 60 * 60) // 7일
+                   .httpOnly(true)          // ✅ JS에서 접근 불가
+                   .secure(true)           // 로컬 개발 시 false
+                   .sameSite("None")
+                   .path("/")
+    //                .domain("iotl.store")
+                   .build();
+       }
+
+    // //로컬 테스트용
+    // public ResponseCookie createAccessCookie(String value) {
+    //     return ResponseCookie.from("access", value)
+    //         .maxAge(7 * 24 * 60 * 60) // 7일
+    //         .httpOnly(false) // ✅ JS에서 접근 가능
+    //         .secure(false)   // 로컬 개발 시 false
+    //         .sameSite("Lax")
+    //         .path("/")
+    //         //                .domain("iotl.store")
+    //         .build();
+    // }
     //
-    //    public ResponseCookie createRefreshCookie(String value) {
-    //        return ResponseCookie.from("refresh", value)
-    //                .maxAge(7 * 24 * 60 * 60) // 7일
-    //                .httpOnly(true)          // ✅ JS에서 접근 불가
-    //                .secure(true)           // 로컬 개발 시 false
-    //                .sameSite("None")
-    //                .path("/")
-    // //                .domain("iotl.store")
-    //                .build();
-    //    }
-
-    //로컬 테스트용
-    public ResponseCookie createAccessCookie(String value) {
-        return ResponseCookie.from("access", value)
-            .maxAge(7 * 24 * 60 * 60) // 7일
-            .httpOnly(false) // ✅ JS에서 접근 가능
-            .secure(false)   // 로컬 개발 시 false
-            .sameSite("Lax")
-            .path("/")
-            //                .domain("iotl.store")
-            .build();
-    }
-
-    public ResponseCookie createRefreshCookie(String value) {
-        return ResponseCookie.from("refresh", value)
-            .maxAge(7 * 24 * 60 * 60) // 7일
-            .httpOnly(false)          // ✅ JS에서 접근 불가
-            .secure(false)           // 로컬 개발 시 false
-            .sameSite("Lax")
-            .path("/")
-            //                .domain("iotl.store")
-            .build();
-    }
+    // public ResponseCookie createRefreshCookie(String value) {
+    //     return ResponseCookie.from("refresh", value)
+    //         .maxAge(7 * 24 * 60 * 60) // 7일
+    //         .httpOnly(false)          // ✅ JS에서 접근 불가
+    //         .secure(false)           // 로컬 개발 시 false
+    //         .sameSite("Lax")
+    //         .path("/")
+    //         //                .domain("iotl.store")
+    //         .build();
+    // }
 }
 

--- a/src/main/java/com/example/iotl/service/security/TokenService.java
+++ b/src/main/java/com/example/iotl/service/security/TokenService.java
@@ -69,48 +69,50 @@ public class TokenService {
         return tokenMap;
     }
 
-   public ResponseCookie createAccessCookie(String value) {
-       return ResponseCookie.from("access", value)
-               .maxAge(7 * 24 * 60 * 60) // 7일
-               .httpOnly(false) // ✅ JS에서 접근 가능
-               .secure(true)   // 로컬 개발 시 false
-               .sameSite("None")
-               .path("/")
-//                .domain("iotl.store")
-               .build();
-   }
+    //배포용
+    //    public ResponseCookie createAccessCookie(String value) {
+    //        return ResponseCookie.from("access", value)
+    //                .maxAge(7 * 24 * 60 * 60) // 7일
+    //                .httpOnly(false) // ✅ JS에서 접근 가능
+    //                .secure(true)   // 로컬 개발 시 false
+    //                .sameSite("None")
+    //                .path("/")
+    // //                .domain("iotl.store")
+    //                .build();
+    //    }
+    //
+    //    public ResponseCookie createRefreshCookie(String value) {
+    //        return ResponseCookie.from("refresh", value)
+    //                .maxAge(7 * 24 * 60 * 60) // 7일
+    //                .httpOnly(true)          // ✅ JS에서 접근 불가
+    //                .secure(true)           // 로컬 개발 시 false
+    //                .sameSite("None")
+    //                .path("/")
+    // //                .domain("iotl.store")
+    //                .build();
+    //    }
 
-   public ResponseCookie createRefreshCookie(String value) {
-       return ResponseCookie.from("refresh", value)
-               .maxAge(7 * 24 * 60 * 60) // 7일
-               .httpOnly(true)          // ✅ JS에서 접근 불가
-               .secure(true)           // 로컬 개발 시 false
-               .sameSite("None")
-               .path("/")
-//                .domain("iotl.store")
-               .build();
-   }
+    //로컬 테스트용
+    public ResponseCookie createAccessCookie(String value) {
+        return ResponseCookie.from("access", value)
+            .maxAge(7 * 24 * 60 * 60) // 7일
+            .httpOnly(false) // ✅ JS에서 접근 가능
+            .secure(false)   // 로컬 개발 시 false
+            .sameSite("Lax")
+            .path("/")
+            //                .domain("iotl.store")
+            .build();
+    }
 
-// public ResponseCookie createAccessCookie(String value) {
-//     return ResponseCookie.from("access", value)
-//             .maxAge(7 * 24 * 60 * 60) // 7일
-//             .httpOnly(false) // ✅ JS에서 접근 가능
-//             .secure(false)   // 로컬 개발 시 false
-//             .sameSite("Lax")
-//             .path("/")
-// //                .domain("iotl.store")
-//             .build();
-// }
-//
-//     public ResponseCookie createRefreshCookie(String value) {
-//         return ResponseCookie.from("refresh", value)
-//                 .maxAge(7 * 24 * 60 * 60) // 7일
-//                 .httpOnly(false)          // ✅ JS에서 접근 불가
-//                 .secure(false)           // 로컬 개발 시 false
-//                 .sameSite("Lax")
-//                 .path("/")
-// //                .domain("iotl.store")
-//                 .build();
-//     }
+    public ResponseCookie createRefreshCookie(String value) {
+        return ResponseCookie.from("refresh", value)
+            .maxAge(7 * 24 * 60 * 60) // 7일
+            .httpOnly(false)          // ✅ JS에서 접근 불가
+            .secure(false)           // 로컬 개발 시 false
+            .sameSite("Lax")
+            .path("/")
+            //                .domain("iotl.store")
+            .build();
+    }
 }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,8 +62,8 @@ spring:
             client-name: kakao
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
-            #            redirect-uri: https://iotl.store/login/oauth2/code/kakao
-            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            redirect-uri: https://iotl.store/login/oauth2/code/kakao
+#            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
             scope:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,7 +62,8 @@ spring:
             client-name: kakao
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
-            redirect-uri: https://iotl.store/login/oauth2/code/kakao
+            #            redirect-uri: https://iotl.store/login/oauth2/code/kakao
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
             scope:
@@ -116,18 +117,19 @@ sentry:
 
 permit-all-paths:
   paths:
-    - /
-    - /login
-    - /login/oauth2
-    - /oauth2
-    - /reissue
-    - /auth/ws/**
-    - /auth/api/stocks/**
-    - /auth/api/exchange
-    - /auth/api/market-index/**
-    - /auth/api/v1/news/top3
-    - /v3/api-docs/
-    - /swagger-ui/
-    - /swagger-ui.html
-    - /test
-    - /api/**
+    - /auth/**
+#    - /**
+#    - /login
+#    - /login/oauth2
+#    - /oauth2
+#    - /reissue
+#    - /ws/**
+#    - /api/stocks/**
+#    - /api/exchange
+#    - /api/market-index/**
+#    - /api/v1/news/top3
+#    - /v3/api-docs/
+#    - /swagger-ui/
+#    - /swagger-ui.html
+#    - /test
+#    - /api/**


### PR DESCRIPTION
## PR 종류
사용하지 않는 PR 종류는 삭제해주세요  
- [x] 기능 개선
- [x] 새로운 기능
- [ ] 리팩토링
- [x] 문서 수정
- [ ] 기타

## 변경 사항

- api 컨벤션을 적용하여 /auth 로 시작하는 경로는 모두 인증없이 통과
- 나머지 api들은 access token으로 인증되어 해당 토큰에서 username 파싱

## 관련 이슈

- 관련된 이슈 번호를 적어주세요 (#issue_number)

## 체크리스트

- [ ] 테스트 코드를 작성하였나요?
- [ ] 모든 테스트가 통과하나요?
- [ ] 관련 문서를 업데이트했나요?
- [ ] 코드 컨벤션을 지켰나요?

## 상세 내용

- AuthenticationUtils.getCurrentUsername()의 정적 메서드 사용으로 username 추출 가능 
![image](https://github.com/user-attachments/assets/e210bf30-14da-4a46-8ff4-9928484fd1a3)

- postman으로 테스트할때는 노션에 정리된 상태로 세팅 필요


## 기타

- 추가로 알려야 할 사항이 있다면 적어주세요.
