### PR TITLE
[FEAT] 실현 수익 구현 #127

### DIFF
--- a/src/main/java/com/example/iotl/entity/Accounts.java
+++ b/src/main/java/com/example/iotl/entity/Accounts.java
@@ -39,6 +39,9 @@ public class Accounts {
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
+    @Column(name = "realized_profit", nullable = false, precision = 20, scale = 2)
+    private BigDecimal realizedProfit = BigDecimal.ZERO;
+
     @PrePersist
     protected void onCreate(){
         this.createdAt = LocalDateTime.now();

--- a/src/main/java/com/example/iotl/service/TradeService.java
+++ b/src/main/java/com/example/iotl/service/TradeService.java
@@ -78,6 +78,11 @@ public class TradeService {
             sellerAccount.getBalance().add(totalCost).setScale(2, RoundingMode.HALF_UP)
         );
 
+        BigDecimal realizedProfit = totalCost.setScale(2, RoundingMode.HALF_UP);
+        sellerAccount.setRealizedProfit(
+            sellerAccount.getRealizedProfit().add(realizedProfit)
+        );
+
         // 9. 주식 이동
         sellerHoldings.setQuantity(sellerHoldings.getQuantity() - tradeQuantity);
         buyerHoldings.setQuantity(buyerHoldings.getQuantity() + tradeQuantity);

--- a/src/test/java/com/example/iotl/service/TradeServiceTest.java
+++ b/src/test/java/com/example/iotl/service/TradeServiceTest.java
@@ -1,0 +1,98 @@
+package com.example.iotl.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.example.iotl.entity.Accounts;
+import com.example.iotl.entity.Holdings;
+import com.example.iotl.entity.Order;
+import com.example.iotl.entity.Order.OrderStatus;
+import com.example.iotl.entity.Order.OrderType;
+import com.example.iotl.entity.StockDetail;
+import com.example.iotl.entity.Stocks;
+import com.example.iotl.entity.User;
+import com.example.iotl.repository.AccountsRepository;
+import com.example.iotl.repository.HoldingsRepository;
+import com.example.iotl.repository.OrderRepository;
+import com.example.iotl.repository.StocksRepository;
+import com.example.iotl.repository.UserRepository;
+import com.example.iotl.testUtil.TestEntityFactory;
+import jakarta.persistence.EntityManager;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@DisplayName("실현 수익 누적 테스트")
+class TradeServiceTest {
+
+    @Autowired
+    private TradeService tradeService;
+
+    @Autowired
+    private AccountsRepository accountsRepository;
+
+    @Autowired
+    private HoldingsRepository holdingsRepository;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    StocksRepository stocksRepository;
+
+    @Autowired
+    private EntityManager em; // flush 용도
+
+    @Test
+    void 매도자는_실현수익이_정상적으로_누적된다() {
+        // given
+        User buyer = userRepository.save(TestEntityFactory.createUser("buyer")); // 🔥 save 추가
+        User seller = userRepository.save(TestEntityFactory.createUser("seller")); // 🔥 save 추가
+        Stocks stock = stocksRepository.save(TestEntityFactory.createStock("삼성전자")); // 🔥 save 추가
+
+        Accounts buyerAccount = accountsRepository.save(
+            Accounts.builder().user(buyer).balance(new BigDecimal("1000000")).realizedProfit(BigDecimal.ZERO).build()
+        );
+        Accounts sellerAccount = accountsRepository.save(
+            Accounts.builder().user(seller).balance(new BigDecimal("0")).realizedProfit(BigDecimal.ZERO).build()
+        );
+
+        holdingsRepository.save(
+            Holdings.builder().user(seller).stock(stock).quantity(10).averageBuyPrice(new BigDecimal("1000")).build()
+        );
+
+        Order buyOrder = orderRepository.save(
+            Order.builder().user(buyer).status(OrderStatus.PENDING).stock(stock).orderType(OrderType.BUY).price(new BigDecimal("50000")).quantity(5).build()
+        );
+
+        Order sellOrder = orderRepository.save(
+            Order.builder().user(seller).stock(stock).status(OrderStatus.PENDING).orderType(OrderType.SELL).price(new BigDecimal("50000")).quantity(5).build()
+        );
+
+        em.flush();
+        em.clear();
+
+        // when
+        tradeService.trade(buyOrder, sellOrder);
+
+        // then
+        Accounts updatedSellerAccount = accountsRepository.findByUserWithPessimisticLock(seller)
+            .orElseThrow();
+
+        BigDecimal expectedProfit = new BigDecimal("50000").multiply(BigDecimal.valueOf(5)).setScale(2);
+
+        assertEquals(expectedProfit, updatedSellerAccount.getRealizedProfit());
+        System.out.println("📈 판매자 실현 수익: " + updatedSellerAccount.getRealizedProfit());
+
+    }
+
+}

--- a/src/test/java/com/example/iotl/testUtil/TestEntityFactory.java
+++ b/src/test/java/com/example/iotl/testUtil/TestEntityFactory.java
@@ -1,0 +1,24 @@
+package com.example.iotl.testUtil;
+
+import com.example.iotl.entity.Stocks;
+import com.example.iotl.entity.User;
+
+public class TestEntityFactory {
+
+    public static User createUser(String name) {
+        return User.builder()
+            .username("SELLER" + System.nanoTime()) // OAuth2 기준 username
+            .name("seller")
+            .role("USER")
+            .profileImage("blahblah")
+            .email("seller" + System.currentTimeMillis() + "@test.com")
+            .build();
+    }
+
+    public static Stocks createStock(String name) {
+        return Stocks.builder()
+            .stockName(name)
+            .stockCode("005930")  // 삼성전자 예시
+            .build();
+    }
+}


### PR DESCRIPTION
## PR 종류

- [o] 새로운 기능


## 변경 사항

판매된 주식 금액을 판매자의 계좌에 저장

## 관련 이슈

#127 

## 체크리스트

- [ o ] 테스트 코드를 작성하였나요?
- [ o ] 모든 테스트가 통과하나요?

## 상세 내용

<img width="772" height="368" alt="image" src="https://github.com/user-attachments/assets/a9a5c61e-0618-4676-bcbd-628fa3b695c0" />

ALTER TABLE `accounts`
    ADD COLUMN `realized_profit` decimal(20,2) DEFAULT '0.00' AFTER `balance`; 
    로컬 테스트 디비에 넣어주셔야 합니다~~ 귀찮다면 test-yml -> 
    ddl auto update 한번 바꿨다가 다시 none으로 바꿔주셔도 무방합니다



## 기타

- 추가로 알려야 할 사항이 있다면 적어주세요.
