### PR TITLE
[FEAT] 투자 모아보기 - 나의 금액 구현

### DIFF
--- a/src/main/java/com/example/iotl/controller/AccountController.java
+++ b/src/main/java/com/example/iotl/controller/AccountController.java
@@ -2,11 +2,14 @@ package com.example.iotl.controller;
 
 import com.example.iotl.dto.AccountSummaryDto;
 import com.example.iotl.dto.deposit.DepositRequest;
+import com.example.iotl.global.response.BaseResponse;
+import com.example.iotl.global.response.BaseResponseService;
 import com.example.iotl.jwt.AuthenticationUtils;
 import com.example.iotl.service.AccountService;
 import java.math.BigDecimal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AccountController {
 
     private final AccountService accountService;
+    private final BaseResponseService baseResponseService;
 
     @PostMapping("/deposit")
     public String depositMoney(@RequestBody DepositRequest request) {
@@ -38,14 +42,18 @@ public class AccountController {
 
 
 
-        @GetMapping("/summary")
-        public AccountSummaryDto getSummary() {
-            String username = AuthenticationUtils.getCurrentUsername();
-            if (username == null) {
-                throw new IllegalStateException("인증된 사용자 아님");
-            }
-            return accountService.getAccountSummary(username);
+
+    @GetMapping("/summary")
+    public ResponseEntity<BaseResponse<AccountSummaryDto>> getSummary() {
+        String username = AuthenticationUtils.getCurrentUsername();
+        if (username == null) {
+            return ResponseEntity.status(401)
+                .body(baseResponseService.getFailureResponse("인증된 사용자가 아닙니다.", 401));
         }
+
+        AccountSummaryDto summary = accountService.getAccountSummary(username);
+        return ResponseEntity.ok(baseResponseService.getSuccessResponse(summary));
+    }
 
 
 }

--- a/src/main/java/com/example/iotl/controller/AccountController.java
+++ b/src/main/java/com/example/iotl/controller/AccountController.java
@@ -1,11 +1,13 @@
 package com.example.iotl.controller;
 
+import com.example.iotl.dto.AccountSummaryDto;
 import com.example.iotl.dto.deposit.DepositRequest;
 import com.example.iotl.jwt.AuthenticationUtils;
 import com.example.iotl.service.AccountService;
 import java.math.BigDecimal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,4 +35,17 @@ public class AccountController {
         accountService.deposit(username, amount);
         return "💰 입금이 완료되었습니다.";
     }
+
+
+
+        @GetMapping("/summary")
+        public AccountSummaryDto getSummary() {
+            String username = AuthenticationUtils.getCurrentUsername();
+            if (username == null) {
+                throw new IllegalStateException("인증된 사용자 아님");
+            }
+            return accountService.getAccountSummary(username);
+        }
+
+
 }

--- a/src/main/java/com/example/iotl/controller/HoldingController.java
+++ b/src/main/java/com/example/iotl/controller/HoldingController.java
@@ -1,12 +1,11 @@
 package com.example.iotl.controller;
 
-import com.example.iotl.dto.security.CustomOAuth2User;
 import com.example.iotl.dto.holding.MyStockSummaryDto;
+import com.example.iotl.jwt.AuthenticationUtils;
 import com.example.iotl.service.HoldingService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -19,12 +18,13 @@ public class HoldingController {
     @Operation(summary = "내 주식 요약 조회", description = "현재 로그인한 유저가 보유한 특정 종목의 평균가, 수수료, 수익을 반환합니다.")
     @GetMapping("/{stockCode}")
     public MyStockSummaryDto getMyStockSummary(
-        @Parameter(description = "종목 코드 (예: 005930)")
-        @PathVariable String stockCode,
-        @AuthenticationPrincipal CustomOAuth2User principal
+        @Parameter(description = "종목 코드 (예: 005930)") @PathVariable String stockCode
     ) {
-        String userName = principal.getUsername();
+        String username = AuthenticationUtils.getCurrentUsername();
+        if (username == null) {
+            throw new IllegalStateException("인증된 사용자가 아닙니다.");
+        }
 
-        return holdingService.getMyStockSummary(userName, stockCode);
+        return holdingService.getMyStockSummary(username, stockCode);
     }
 }

--- a/src/main/java/com/example/iotl/dto/AccountSummaryDto.java
+++ b/src/main/java/com/example/iotl/dto/AccountSummaryDto.java
@@ -1,0 +1,16 @@
+package com.example.iotl.dto;
+
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AccountSummaryDto {
+    private BigDecimal availableAmount;
+    private BigDecimal investingAmount;
+}

--- a/src/main/java/com/example/iotl/repository/AccountsRepository.java
+++ b/src/main/java/com/example/iotl/repository/AccountsRepository.java
@@ -15,4 +15,7 @@ public interface AccountsRepository extends JpaRepository<Accounts,Long> {
     @Query("select a from Accounts a where a.user = :user")
     Optional<Accounts> findByUserWithPessimisticLock(@Param("user") User user);
 
+    Optional<Accounts> findByUser_Username(String username);
+
+
 }

--- a/src/main/java/com/example/iotl/repository/HoldingsRepository.java
+++ b/src/main/java/com/example/iotl/repository/HoldingsRepository.java
@@ -26,4 +26,6 @@ public interface HoldingsRepository extends JpaRepository<Holdings,Long> {
     @Query("select h from Holdings h where h.user = :user and h.stock = :stock")
     Optional<Holdings> findByUserAndStockWithPessimisticLock(@Param("user") User user, @Param("stock") Stocks stock);
 
+    List<Holdings> findByUser_Username(String username);
+
 }

--- a/src/main/java/com/example/iotl/service/AccountService.java
+++ b/src/main/java/com/example/iotl/service/AccountService.java
@@ -1,10 +1,16 @@
 package com.example.iotl.service;
 
+import com.example.iotl.dto.AccountSummaryDto;
 import com.example.iotl.dto.deposit.DepositRequest;
 import com.example.iotl.entity.Accounts;
+import com.example.iotl.entity.Holdings;
+import com.example.iotl.entity.StockDetail;
 import com.example.iotl.entity.User;
 import com.example.iotl.repository.AccountsRepository;
+import com.example.iotl.repository.HoldingsRepository;
+import com.example.iotl.repository.StockDetailRepository;
 import com.example.iotl.repository.UserRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +22,9 @@ public class AccountService {
 
     private final AccountsRepository accountsRepository;
     private final UserRepository userRepository;
+    private final HoldingsRepository holdingsRepository;
+    private final StockDetailRepository stockDetailRepository;
+
 
     @Transactional
     public void deposit(String username, BigDecimal amount) {
@@ -31,4 +40,27 @@ public class AccountService {
 
         account.setBalance(account.getBalance().add(amount));
     }
+
+    public AccountSummaryDto getAccountSummary(String username) {
+        Accounts account = accountsRepository.findByUser_Username(username)
+            .orElseThrow(() -> new RuntimeException("계좌 없음"));
+
+        BigDecimal balance = account.getBalance();
+
+        List<Holdings> holdings = holdingsRepository.findByUser_Username(username);
+
+        BigDecimal investingAmount = holdings.stream()
+            .map(h -> {
+                BigDecimal currentPrice = stockDetailRepository
+                    .findTopByStocks_StockCodeOrderByCreatedAtDesc(h.getStock().getStockCode())
+                    .map(StockDetail::getClosePrice)
+                    .orElse(BigDecimal.ZERO);
+                return currentPrice.multiply(BigDecimal.valueOf(h.getQuantity()));
+            })
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        return new AccountSummaryDto(balance, investingAmount);
+    }
+
+
 }


### PR DESCRIPTION
## PR 종류
- [x] 새로운 기능
- [ ] 기능 개선
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항

- 로그인한 사용자의 주문 가능 금액(예수금)과 현재 투자 중인 금액을 반환하는 API 구현
- `AccountService.getAccountSummary(String username)` 추가
- `AccountsRepository.findByUser_Username()` / `HoldingsRepository.findByUser_Username()` 메서드 추가
- DTO: `AccountSummaryDto` 생성

## 관련 이슈
- #131 



## 상세 내용

### Endpoint
