### PR TITLE
[FEAT] 보유 종목 없을 때 0으로 초기화된 주식 요약 정보 반환하도록 수정

### DIFF
--- a/src/main/java/com/example/iotl/service/HoldingServiceImpl.java
+++ b/src/main/java/com/example/iotl/service/HoldingServiceImpl.java
@@ -25,12 +25,22 @@ public class HoldingServiceImpl implements HoldingService {
     private final StockDetailRepository stockDetailRepository;
     private final UserRepository userRepository;
 
-    @Override
     public MyStockSummaryDto getMyStockSummary(String userName, String stockCode) {
-        Holdings h = holdingsRepository
-            .findByUser_UsernameAndStock_StockCode(userName, stockCode)
-            .orElseThrow(() -> new RuntimeException("보유 종목이 없습니다."));
+        Optional<Holdings> hOpt = holdingsRepository
+            .findByUser_UsernameAndStock_StockCode(userName, stockCode);
 
+        if (hOpt.isEmpty()) {
+            // 보유 종목이 없을 경우 0으로 응답
+            return MyStockSummaryDto.builder()
+                .averagePrice(BigDecimal.ZERO)
+                .quantity(0)
+                .expectedFee(BigDecimal.ZERO)
+                .totalProfit(BigDecimal.ZERO)
+                .totalAmount(BigDecimal.ZERO)
+                .build();
+        }
+
+        Holdings h = hOpt.get();
         BigDecimal averagePrice = h.getAverageBuyPrice();
         int quantity = h.getQuantity();
 
@@ -42,7 +52,7 @@ public class HoldingServiceImpl implements HoldingService {
         }
 
         BigDecimal currentPrice = stockDetailOpt.get().getClosePrice();
-        BigDecimal totalNowAmount = currentPrice.multiply(BigDecimal.valueOf(quantity));  // ✅ 총 금액 계산
+        BigDecimal totalNowAmount = currentPrice.multiply(BigDecimal.valueOf(quantity));
         BigDecimal fee = totalNowAmount.multiply(new BigDecimal("0.0003"))
             .setScale(0, RoundingMode.HALF_UP);
 
@@ -58,6 +68,7 @@ public class HoldingServiceImpl implements HoldingService {
             .totalAmount(totalNowAmount)
             .build();
     }
+
 
 
     @Override


### PR DESCRIPTION
## PR 종류  
- [x] 기능 개선  
- [ ] 새로운 기능  
- [ ] 리팩토링  
- [ ] 문서 수정  
- [ ] 기타  

## 변경 사항  
- 사용자가 특정 종목을 보유하지 않은 경우, 기존에는 예외를 발생시켰으나  
  → 이제는 `0`으로 초기화된 `MyStockSummaryDto`를 반환하도록 변경  
- 프론트엔드는 예외 케이스를 따로 처리하지 않고도 항상 동일한 형태의 응답을 받을 수 있음.

## 관련 이슈  
- close #142 

## 체크리스트  
- [ ] 테스트 코드를 작성하였나요?  
- [ ] 모든 테스트가 통과하나요?  
- [ ] 관련 문서를 업데이트했나요?  
- [x] 코드 컨벤션을 지켰나요?  

## 상세 내용  
- 예외 대신 평균 단가, 수량, 수수료, 총 수익, 총 금액 모두 0으로 세팅된 응답 반환
- 프론트엔드는 "내 주식" 카드에서 예외 상황 없이 0 데이터로 표시 가능
- API 응답 일관성 향상됨


